### PR TITLE
fix: convert package names to lower case to avoid casing issues

### DIFF
--- a/src/app/app.tsx
+++ b/src/app/app.tsx
@@ -73,7 +73,7 @@ export function App() {
           onKeyDown={(evt: React.KeyboardEvent<HTMLInputElement>) => {
             if (evt.key === 'Enter') {
               const target = evt.target as HTMLInputElement;
-              setNpmPackageName(target.value);
+              setNpmPackageName(target.value?.toLocaleLowerCase());
             }
           }}
           placeholder="NPM Package"


### PR DESCRIPTION
Currently if you use Camel case the package does not match. 

Type `Nx` into the search box and it returns empty results. 

https://www.craigory.dev/npm-burst/?package=Nx

Converting to lowercase resolves the issue. 