### PR TITLE
fix: cancel http request if another comes in

### DIFF
--- a/libs/npm/data-access/src/lib/npm-client.ts
+++ b/libs/npm/data-access/src/lib/npm-client.ts
@@ -4,15 +4,21 @@ export interface NpmDownloadsByVersion {
 }
 
 export function getDownloadsByVersion(pkg: string) {
-  return fetch(
-    `https://api.npmjs.org/versions/${encodeURI(pkg).replace(
-      '/',
-      '%2f'
-    )}/last-week`
-  )
-    .then(async (result) => {
-      const json = await result.json();
-      return json as NpmDownloadsByVersion;
-    })
-    .catch(() => null);
+  const controller = new AbortController();
+  return {
+    get: () =>
+      fetch(
+        `https://api.npmjs.org/versions/${encodeURI(pkg).replace(
+          '/',
+          '%2f'
+        )}/last-week`,
+        { signal: controller.signal }
+      ).then(async (result) => {
+        const json = await result.json();
+        return json as NpmDownloadsByVersion;
+      }),
+    cancel: () => {
+      controller.abort();
+    },
+  };
 }

--- a/src/app/app.spec.tsx
+++ b/src/app/app.spec.tsx
@@ -3,13 +3,18 @@ import { render } from '@testing-library/react';
 import App from './app';
 
 vi.mock('@npm-burst/npm/data-access', () => ({
-  getDownloadsByVersion: (pkg: string) =>
-    Promise.resolve({
-      package: pkg,
-      versions: {
-        '1.0.0': 123,
-      },
-    }),
+  getDownloadsByVersion: (pkg: string) => ({
+    get: () =>
+      Promise.resolve({
+        package: pkg,
+        versions: {
+          '1.0.0': 123,
+        },
+      }),
+    cancel: () => {
+      // no-op
+    },
+  }),
 }));
 
 describe('App', () => {

--- a/src/app/app.tsx
+++ b/src/app/app.tsx
@@ -58,11 +58,22 @@ export function App() {
   );
 
   useEffect(() => {
+    const { get, cancel } = getDownloadsByVersion(npmPackageName);
     if (npmPackageName) {
-      getDownloadsByVersion(npmPackageName).then((downloads) => {
-        setRawDownloadData(downloads);
-      });
+      get()
+        .then((downloads) => {
+          if (downloads) {
+            setRawDownloadData(downloads);
+          }
+        })
+        .catch((e) => {
+          // do nothing - probably a cnacellation
+          // can check in future via e.name === `AbortError`
+        });
     }
+    return () => {
+      cancel();
+    };
   }, [npmPackageName]);
 
   useEffect(() => {


### PR DESCRIPTION
## What it does:

Adds a cancel option to the npm client to cancel a request when we fire multiple at app initialization.