### PR TITLE
feat: use npm downloads API for volume chart and add version release ticks


### DIFF
--- a/apps/npm-burst/src/app/components/download-volume-chart.tsx
+++ b/apps/npm-burst/src/app/components/download-volume-chart.tsx
@@ -200,7 +200,7 @@ export const DownloadVolumeChart = memo(function DownloadVolumeChart({
 
         const lines = [
           `<strong>${point.date}</strong>`,
-          `Total: ${formatDownloadCount(point.totalDownloads)} downloads`,
+          `Total: ${formatDownloadCount(point.totalDownloads)} downloads/week`,
         ];
         for (const vr of releasesOnDate) {
           lines.push(

--- a/apps/npm-burst/src/app/components/download-volume-chart.tsx
+++ b/apps/npm-burst/src/app/components/download-volume-chart.tsx
@@ -1,8 +1,7 @@
 import * as d3 from 'd3';
 import { memo, useEffect, useMemo, useRef } from 'react';
-import type { Snapshot } from '../../server/functions/snapshots.telefunc';
+import type { DailyDownloadPoint } from '../../server/functions/total-downloads.telefunc';
 import type { VersionRelease } from '../../server/functions/versions.telefunc';
-import type { NpmDownloadsByVersion } from '@npm-burst/npm-data-access';
 import { useTheme } from '../context/theme-context';
 import { getThemeChartColors } from '../utils/theme-colors';
 import {
@@ -15,12 +14,10 @@ const MARGIN = { top: 20, right: 20, bottom: 40, left: 60 };
 const CHART_HEIGHT = 350;
 
 export const DownloadVolumeChart = memo(function DownloadVolumeChart({
-  snapshots,
-  liveData,
+  totalDownloads,
   versionReleases,
 }: {
-  snapshots: Snapshot[];
-  liveData: NpmDownloadsByVersion | null;
+  totalDownloads: DailyDownloadPoint[];
   versionReleases: VersionRelease[];
 }) {
   const { theme } = useTheme();
@@ -28,8 +25,8 @@ export const DownloadVolumeChart = memo(function DownloadVolumeChart({
   const containerRef = useRef<HTMLDivElement>(null);
 
   const volumeData = useMemo(
-    () => getDownloadVolumeData(snapshots, liveData),
-    [snapshots, liveData]
+    () => getDownloadVolumeData(totalDownloads),
+    [totalDownloads]
   );
 
   const chartColors = getThemeChartColors(theme);
@@ -44,14 +41,14 @@ export const DownloadVolumeChart = memo(function DownloadVolumeChart({
     const innerWidth = width - MARGIN.left - MARGIN.right;
     const innerHeight = height - MARGIN.top - MARGIN.bottom;
 
-    const allDates = volumeData.map((d) => d.date);
+    const parseDate = (d: string) => new Date(d + 'T00:00:00');
+    const dates = volumeData.map((d) => parseDate(d.date));
     const maxDownloads = d3.max(volumeData, (d) => d.totalDownloads) ?? 0;
 
     const xScale = d3
-      .scalePoint<string>()
-      .domain(allDates)
-      .range([0, innerWidth])
-      .padding(0.1);
+      .scaleTime()
+      .domain(d3.extent(dates) as [Date, Date])
+      .range([0, innerWidth]);
 
     const yScale = d3
       .scaleLinear()
@@ -78,19 +75,14 @@ export const DownloadVolumeChart = memo(function DownloadVolumeChart({
       );
 
     // X axis
-    const tickInterval = Math.max(1, Math.floor(allDates.length / 8));
-    const tickValues = allDates.filter((_, i) => i % tickInterval === 0);
     g.append('g')
       .attr('class', 'axis')
       .attr('transform', `translate(0,${innerHeight})`)
       .call(
         d3
           .axisBottom(xScale)
-          .tickValues(tickValues)
-          .tickFormat((d) => {
-            const date = new Date(d + 'T00:00:00');
-            return d3.timeFormat('%b %d, %Y')(date);
-          })
+          .ticks(8)
+          .tickFormat((d) => d3.timeFormat('%b %d, %Y')(d as Date))
       )
       .selectAll('text')
       .attr('transform', 'rotate(-25)')
@@ -109,7 +101,7 @@ export const DownloadVolumeChart = memo(function DownloadVolumeChart({
     // Area fill
     const areaGen = d3
       .area<{ date: string; totalDownloads: number }>()
-      .x((d) => xScale(d.date) ?? 0)
+      .x((d) => xScale(parseDate(d.date)))
       .y0(innerHeight)
       .y1((d) => yScale(d.totalDownloads))
       .curve(d3.curveMonotoneX);
@@ -126,7 +118,7 @@ export const DownloadVolumeChart = memo(function DownloadVolumeChart({
     // Line
     const lineGen = d3
       .line<{ date: string; totalDownloads: number }>()
-      .x((d) => xScale(d.date) ?? 0)
+      .x((d) => xScale(parseDate(d.date)))
       .y((d) => yScale(d.totalDownloads))
       .curve(d3.curveMonotoneX);
 
@@ -137,28 +129,22 @@ export const DownloadVolumeChart = memo(function DownloadVolumeChart({
       .attr('stroke-width', 2.5)
       .attr('d', lineGen);
 
-    // Dots
-    g.selectAll(null)
-      .data(volumeData)
-      .join('circle')
-      .attr('cx', (d) => xScale(d.date) ?? 0)
-      .attr('cy', (d) => yScale(d.totalDownloads))
-      .attr('r', 3)
-      .attr('fill', lineColor)
-      .attr('stroke', theme === 'dark' ? '#1e1e1e' : '#ffffff')
-      .attr('stroke-width', 1.5);
-
-    // Version release markers
+    // Version release markers (vertical ticks)
+    const [domainStart, domainEnd] = xScale.domain();
     for (const vr of versionReleases) {
-      const x = xScale(vr.date);
-      if (x === undefined) continue;
+      const vrDate = parseDate(vr.date);
+      if (vrDate < domainStart || vrDate > domainEnd) continue;
 
+      const x = xScale(vrDate);
       g.append('line')
         .attr('x1', x)
         .attr('x2', x)
         .attr('y1', 0)
         .attr('y2', innerHeight)
-        .attr('stroke', theme === 'dark' ? 'rgba(255,255,255,0.15)' : 'rgba(0,0,0,0.1)')
+        .attr(
+          'stroke',
+          theme === 'dark' ? 'rgba(255,255,255,0.15)' : 'rgba(0,0,0,0.1)'
+        )
         .attr('stroke-width', 1)
         .attr('stroke-dasharray', '4,3');
     }
@@ -189,27 +175,32 @@ export const DownloadVolumeChart = memo(function DownloadVolumeChart({
       .attr('fill', 'transparent')
       .on('mousemove', (event: MouseEvent) => {
         const [mx] = d3.pointer(event);
-        let closestDate = allDates[0];
+        const hoveredDate = xScale.invert(mx);
+
+        // Find closest data point
+        let closestIdx = 0;
         let closestDist = Infinity;
-        for (const date of allDates) {
-          const dx = Math.abs((xScale(date) ?? 0) - mx);
-          if (dx < closestDist) {
-            closestDist = dx;
-            closestDate = date;
+        for (let i = 0; i < volumeData.length; i++) {
+          const dist = Math.abs(
+            parseDate(volumeData[i].date).getTime() - hoveredDate.getTime()
+          );
+          if (dist < closestDist) {
+            closestDist = dist;
+            closestIdx = i;
           }
         }
 
-        const point = volumeData.find((d) => d.date === closestDate);
+        const point = volumeData[closestIdx];
         if (!point) return;
 
         // Check if any version was released on this date
         const releasesOnDate = versionReleases.filter(
-          (vr) => vr.date === closestDate
+          (vr) => vr.date === point.date
         );
 
         const lines = [
-          `<strong>${closestDate}</strong>`,
-          `Total: ${formatDownloadCount(point.totalDownloads)} downloads/week`,
+          `<strong>${point.date}</strong>`,
+          `Total: ${formatDownloadCount(point.totalDownloads)} downloads`,
         ];
         for (const vr of releasesOnDate) {
           lines.push(
@@ -220,7 +211,7 @@ export const DownloadVolumeChart = memo(function DownloadVolumeChart({
         const containerRect = containerRef.current!.getBoundingClientRect();
         const svgRect = svgRef.current!.getBoundingClientRect();
         const tooltipX =
-          (xScale(closestDate) ?? 0) +
+          xScale(parseDate(point.date)) +
           MARGIN.left +
           (svgRect.left - containerRect.left) +
           15;
@@ -235,8 +226,8 @@ export const DownloadVolumeChart = memo(function DownloadVolumeChart({
         g.selectAll('.hover-line').remove();
         g.append('line')
           .attr('class', 'hover-line')
-          .attr('x1', xScale(closestDate) ?? 0)
-          .attr('x2', xScale(closestDate) ?? 0)
+          .attr('x1', xScale(parseDate(point.date)))
+          .attr('x2', xScale(parseDate(point.date)))
           .attr('y1', 0)
           .attr('y2', innerHeight)
           .attr('stroke', chartColors.tooltipBorder)
@@ -252,8 +243,7 @@ export const DownloadVolumeChart = memo(function DownloadVolumeChart({
   if (volumeData.length === 0) {
     return (
       <div className={styles.noData}>
-        No historical snapshot data available. Track this package to start
-        collecting download volume data over time.
+        No download volume data available for this package.
       </div>
     );
   }

--- a/apps/npm-burst/src/app/components/version-adoption-chart.tsx
+++ b/apps/npm-burst/src/app/components/version-adoption-chart.tsx
@@ -218,6 +218,34 @@ export const VersionAdoptionChart = memo(function VersionAdoptionChart({
         .attr('stroke-width', 1.5);
     }
 
+    // Version release markers (vertical ticks)
+    if (allDates.length >= 2) {
+      const firstDate = new Date(allDates[0] + 'T00:00:00');
+      const lastDate = new Date(allDates[allDates.length - 1] + 'T00:00:00');
+      const timeScale = d3
+        .scaleTime()
+        .domain([firstDate, lastDate])
+        .range([xScale(allDates[0]) ?? 0, xScale(allDates[allDates.length - 1]) ?? innerWidth]);
+
+      for (const vr of versionReleases) {
+        const vrDate = new Date(vr.date + 'T00:00:00');
+        if (vrDate < firstDate || vrDate > lastDate) continue;
+
+        const x = timeScale(vrDate);
+        g.append('line')
+          .attr('x1', x)
+          .attr('x2', x)
+          .attr('y1', 0)
+          .attr('y2', innerHeight)
+          .attr(
+            'stroke',
+            theme === 'dark' ? 'rgba(255,255,255,0.15)' : 'rgba(0,0,0,0.1)'
+          )
+          .attr('stroke-width', 1)
+          .attr('stroke-dasharray', '4,3');
+      }
+    }
+
     // Tooltip
     const tooltip = d3
       .select(containerRef.current)
@@ -301,7 +329,7 @@ export const VersionAdoptionChart = memo(function VersionAdoptionChart({
         tooltip.style('opacity', 0);
         g.selectAll('.hover-line').remove();
       });
-  }, [series, visibleSeries, theme, colorMap, chartColors]);
+  }, [series, visibleSeries, versionReleases, theme, colorMap, chartColors]);
 
   if (series.length === 0) {
     return (

--- a/apps/npm-burst/src/app/hooks/use-package-data.ts
+++ b/apps/npm-burst/src/app/hooks/use-package-data.ts
@@ -1,7 +1,11 @@
-import { getDownloadsByVersion } from '@npm-burst/npm-data-access';
+import {
+  getDownloadsByVersion,
+  getTotalDownloadsRange,
+} from '@npm-burst/npm-data-access';
 import { useEffect, useRef } from 'react';
 import { onGetDownloads } from '../../server/functions/downloads.telefunc';
 import { onGetSnapshots } from '../../server/functions/snapshots.telefunc';
+import { onGetTotalDownloads } from '../../server/functions/total-downloads.telefunc';
 import { onGetVersionDates } from '../../server/functions/versions.telefunc';
 import { useSafeAuth } from '../context/auth-context';
 import { appStore, useAppStore } from '../store';
@@ -54,13 +58,31 @@ export function usePackageData() {
       .then(({ versions }) => versions)
       .catch(() => []);
 
-    Promise.all([fetchLive, fetchSnapshots, fetchVersions])
-      .then(([liveData, snapshots, versions]) => {
+    // Fetch total downloads for last 18 months (npm API max range)
+    const end = new Date().toISOString().slice(0, 10);
+    const startDate = new Date();
+    startDate.setMonth(startDate.getMonth() - 18);
+    const start = startDate.toISOString().slice(0, 10);
+
+    const fetchTotalDownloads = isSignedIn
+      ? onGetTotalDownloads(npmPackageName, start, end)
+          .then(({ downloads }) => downloads)
+          .catch(() => [])
+      : (() => {
+          const { get } = getTotalDownloadsRange(npmPackageName, start, end);
+          return get()
+            .then((data) => data.downloads)
+            .catch(() => []);
+        })();
+
+    Promise.all([fetchLive, fetchSnapshots, fetchVersions, fetchTotalDownloads])
+      .then(([liveData, snapshots, versions, totalDownloads]) => {
         if (cancelled) return;
         const s = appStore.getState();
         s.setLiveData(liveData);
         s.setSnapshots(snapshots);
         s.setVersionReleases(versions);
+        s.setTotalDownloads(totalDownloads);
         s.setSnapshotIndex(null);
         s.cacheCurrentPackageData();
         s.recomputeChartData();

--- a/apps/npm-burst/src/app/package-dashboard.tsx
+++ b/apps/npm-burst/src/app/package-dashboard.tsx
@@ -60,6 +60,7 @@ export function PackageDashboard() {
   const versionReleases = useAppStore((s) => s.versionReleases);
   const viewMode = useAppStore((s) => s.viewMode);
   const liveData = useAppStore((s) => s.liveData);
+  const totalDownloads = useAppStore((s) => s.totalDownloads);
   const lowPassFilter = useAppStore((s) => s.lowPassFilter);
 
   const handleVersionClick = useAppStore((s) => s.handleVersionClick);
@@ -136,8 +137,7 @@ export function PackageDashboard() {
             />
           ) : viewMode === 'volume' ? (
             <DownloadVolumeChart
-              snapshots={snapshots}
-              liveData={liveData}
+              totalDownloads={totalDownloads}
               versionReleases={versionReleases}
             />
           ) : viewMode === 'migration' ? (

--- a/apps/npm-burst/src/app/store/app-store.ts
+++ b/apps/npm-burst/src/app/store/app-store.ts
@@ -2,6 +2,7 @@ import type { NpmDownloadsByVersion } from '@npm-burst/npm-data-access';
 import { useStore } from 'zustand';
 import { createStore } from 'zustand/vanilla';
 import type { Snapshot } from '../../server/functions/snapshots.telefunc';
+import type { DailyDownloadPoint } from '../../server/functions/total-downloads.telefunc';
 import type { VersionRelease } from '../../server/functions/versions.telefunc';
 import type { SunburstData } from '../components/sunburst';
 import {
@@ -20,6 +21,7 @@ interface PackageCache {
   liveData: NpmDownloadsByVersion;
   snapshots: Snapshot[];
   versionReleases: VersionRelease[];
+  totalDownloads: DailyDownloadPoint[];
 }
 
 export interface AppState {
@@ -34,6 +36,7 @@ export interface AppState {
   liveData: NpmDownloadsByVersion | null;
   snapshots: Snapshot[];
   versionReleases: VersionRelease[];
+  totalDownloads: DailyDownloadPoint[];
 
   // Per-package cache
   packageCache: Record<string, PackageCache>;
@@ -63,6 +66,7 @@ export interface AppState {
   setLiveData: (data: NpmDownloadsByVersion | null) => void;
   setSnapshots: (snapshots: Snapshot[]) => void;
   setVersionReleases: (releases: VersionRelease[]) => void;
+  setTotalDownloads: (downloads: DailyDownloadPoint[]) => void;
 
   setSnapshotIndex: (idx: number | null) => void;
   previousSnapshot: () => void;
@@ -115,6 +119,7 @@ export const appStore = createStore<AppState>((set, get) => ({
   liveData: null,
   snapshots: [],
   versionReleases: [],
+  totalDownloads: [],
   packageCache: {},
 
   // Navigation
@@ -150,6 +155,7 @@ export const appStore = createStore<AppState>((set, get) => ({
   setLiveData: (data) => set({ liveData: data }),
   setSnapshots: (snapshots) => set({ snapshots }),
   setVersionReleases: (releases) => set({ versionReleases: releases }),
+  setTotalDownloads: (downloads) => set({ totalDownloads: downloads }),
 
   setSnapshotIndex: (idx) => {
     set({ snapshotIndex: idx });
@@ -266,13 +272,14 @@ export const appStore = createStore<AppState>((set, get) => ({
       liveData,
       snapshots,
       versionReleases,
+      totalDownloads,
       packageCache,
     } = get();
     if (!liveData) return;
     set({
       packageCache: {
         ...packageCache,
-        [npmPackageName]: { liveData, snapshots, versionReleases },
+        [npmPackageName]: { liveData, snapshots, versionReleases, totalDownloads },
       },
     });
   },
@@ -285,6 +292,7 @@ export const appStore = createStore<AppState>((set, get) => ({
       liveData: cached.liveData,
       snapshots: cached.snapshots,
       versionReleases: cached.versionReleases,
+      totalDownloads: cached.totalDownloads,
       snapshotIndex: null,
     });
     return true;

--- a/apps/npm-burst/src/app/utils/download-volume.ts
+++ b/apps/npm-burst/src/app/utils/download-volume.ts
@@ -1,5 +1,4 @@
-import type { Snapshot } from '../../server/functions/snapshots.telefunc';
-import type { NpmDownloadsByVersion } from '@npm-burst/npm-data-access';
+import type { DailyDownloadPoint } from '../../server/functions/total-downloads.telefunc';
 
 export interface VolumePoint {
   date: string;
@@ -7,33 +6,17 @@ export interface VolumePoint {
 }
 
 /**
- * Computes total download volume per snapshot date.
- * Sums all version downloads for each snapshot to get absolute totals.
+ * Converts daily download data from the npm downloads API into volume points.
+ * Uses the total downloads endpoint directly rather than aggregating
+ * per-version data from snapshots.
  */
 export function getDownloadVolumeData(
-  snapshots: Snapshot[],
-  liveData: NpmDownloadsByVersion | null
+  totalDownloads: DailyDownloadPoint[]
 ): VolumePoint[] {
-  const points: VolumePoint[] = snapshots.map((snap) => ({
-    date: snap.date,
-    totalDownloads: Object.values(snap.downloads).reduce(
-      (sum, c) => sum + c,
-      0
-    ),
+  return totalDownloads.map((d) => ({
+    date: d.day,
+    totalDownloads: d.downloads,
   }));
-
-  if (liveData) {
-    const today = new Date().toISOString().slice(0, 10);
-    points.push({
-      date: today,
-      totalDownloads: Object.values(liveData.downloads).reduce(
-        (sum, c) => sum + c,
-        0
-      ),
-    });
-  }
-
-  return points;
 }
 
 /**

--- a/apps/npm-burst/src/app/utils/download-volume.ts
+++ b/apps/npm-burst/src/app/utils/download-volume.ts
@@ -6,17 +6,27 @@ export interface VolumePoint {
 }
 
 /**
- * Converts daily download data from the npm downloads API into volume points.
- * Uses the total downloads endpoint directly rather than aggregating
- * per-version data from snapshots.
+ * Converts daily download data from the npm downloads API into volume points
+ * using a rolling 7-day sum. Each point represents the total downloads for
+ * the preceding 7 days, which smooths out day-of-week noise.
  */
 export function getDownloadVolumeData(
   totalDownloads: DailyDownloadPoint[]
 ): VolumePoint[] {
-  return totalDownloads.map((d) => ({
-    date: d.day,
-    totalDownloads: d.downloads,
-  }));
+  if (totalDownloads.length < 7) return [];
+
+  const points: VolumePoint[] = [];
+  for (let i = 6; i < totalDownloads.length; i++) {
+    let sum = 0;
+    for (let j = i - 6; j <= i; j++) {
+      sum += totalDownloads[j].downloads;
+    }
+    points.push({
+      date: totalDownloads[i].day,
+      totalDownloads: sum,
+    });
+  }
+  return points;
 }
 
 /**

--- a/apps/npm-burst/src/server/fixtures/packages.ts
+++ b/apps/npm-burst/src/server/fixtures/packages.ts
@@ -503,3 +503,52 @@ export function getFixtureVersionDates(
 ): Record<string, string> | null {
   return versionReleaseDates[name] ?? null;
 }
+
+/**
+ * Generate fixture total download data from snapshot fixtures.
+ * Returns daily download points derived from snapshot data by
+ * filling in daily data between snapshot dates with interpolation.
+ */
+export function getFixtureTotalDownloads(
+  name: string
+): { day: string; downloads: number }[] {
+  const snapshots = snapshotFixtures[name];
+  if (!snapshots || snapshots.length === 0) return [];
+
+  const points: { day: string; downloads: number }[] = [];
+
+  for (let i = 0; i < snapshots.length; i++) {
+    const snap = snapshots[i];
+    const total = Object.values(snap.downloads).reduce(
+      (sum, c) => sum + c,
+      0
+    );
+    const startDate = new Date(snap.date + 'T00:00:00');
+
+    if (i < snapshots.length - 1) {
+      const endDate = new Date(snapshots[i + 1].date + 'T00:00:00');
+      const endTotal = Object.values(snapshots[i + 1].downloads).reduce(
+        (sum, c) => sum + c,
+        0
+      );
+      const days = Math.round(
+        (endDate.getTime() - startDate.getTime()) / 86400000
+      );
+
+      for (let d = 0; d < days; d++) {
+        const date = new Date(startDate);
+        date.setDate(date.getDate() + d);
+        const t = d / days;
+        const interpolated = Math.round(total + (endTotal - total) * t);
+        points.push({
+          day: date.toISOString().slice(0, 10),
+          downloads: interpolated,
+        });
+      }
+    } else {
+      points.push({ day: snap.date, downloads: total });
+    }
+  }
+
+  return points;
+}

--- a/apps/npm-burst/src/server/functions/total-downloads.telefunc.ts
+++ b/apps/npm-burst/src/server/functions/total-downloads.telefunc.ts
@@ -1,0 +1,40 @@
+import { getContext } from 'telefunc';
+import { getDb } from '../db';
+import { isDevMode } from '../env';
+import { cachedFetch } from '../npm-fetch';
+import { getFixtureTotalDownloads } from '../fixtures/packages';
+
+export interface DailyDownloadPoint {
+  day: string;
+  downloads: number;
+}
+
+export async function onGetTotalDownloads(
+  pkg: string,
+  start: string,
+  end: string
+): Promise<{ downloads: DailyDownloadPoint[] }> {
+  const { env } = getContext();
+
+  if (isDevMode(env)) {
+    const fixture = getFixtureTotalDownloads(pkg);
+    // Filter to requested range
+    const filtered = fixture.filter((p) => p.day >= start && p.day <= end);
+    return { downloads: filtered };
+  }
+
+  const db = getDb(env);
+  const encodedPkg = encodeURIComponent(pkg);
+  const url = `https://api.npmjs.org/downloads/range/${start}:${end}/${encodedPkg}`;
+  const body = await cachedFetch(db, url);
+  const data = JSON.parse(body) as {
+    downloads?: { day: string; downloads: number }[];
+  };
+
+  return {
+    downloads: (data.downloads ?? []).map((d) => ({
+      day: d.day,
+      downloads: d.downloads,
+    })),
+  };
+}

--- a/libs/npm-data-access/src/lib/npm-client.ts
+++ b/libs/npm-data-access/src/lib/npm-client.ts
@@ -3,6 +3,18 @@ export interface NpmDownloadsByVersion {
   package: string;
 }
 
+export interface NpmDailyDownloadPoint {
+  day: string;
+  downloads: number;
+}
+
+export interface NpmDownloadsRange {
+  downloads: NpmDailyDownloadPoint[];
+  start: string;
+  end: string;
+  package: string;
+}
+
 export function getDownloadsByVersion(pkg: string) {
   const controller = new AbortController();
   return {
@@ -16,6 +28,28 @@ export function getDownloadsByVersion(pkg: string) {
       ).then(async (result) => {
         const json = await result.json();
         return json as NpmDownloadsByVersion;
+      }),
+    cancel: () => {
+      controller.abort();
+    },
+  };
+}
+
+export function getTotalDownloadsRange(
+  pkg: string,
+  start: string,
+  end: string
+) {
+  const controller = new AbortController();
+  const encodedPkg = encodeURI(pkg).replace('/', '%2f');
+  return {
+    get: () =>
+      fetch(
+        `https://api.npmjs.org/downloads/range/${start}:${end}/${encodedPkg}`,
+        { signal: controller.signal }
+      ).then(async (result) => {
+        const json = await result.json();
+        return json as NpmDownloadsRange;
       }),
     cancel: () => {
       controller.abort();


### PR DESCRIPTION
Switch the download volume chart from aggregating per-version snapshot
data to using the npm downloads/range API for total download counts.
This provides daily granularity with authoritative totals directly
from npm. Also add version release date markers as vertical ticks
on both the volume chart and version adoption chart.

https://claude.ai/code/session_011T4Yekf4AzgAn7ov1DgTGj